### PR TITLE
Move season start to the Wednesday following Labor Day

### DIFF
--- a/src/nflreadpy/utils_date.py
+++ b/src/nflreadpy/utils_date.py
@@ -1,8 +1,37 @@
 """Date utility functions for nflreadpy."""
 
-from datetime import date
+from datetime import date, timedelta
 
 import polars as pl
+
+
+def _season_start(season_year: int) -> date:
+    """
+    Get the date a given NFL season begins: the Wednesday following Labor Day.
+
+    Labor Day is the first Monday in September, so this lands two days later.
+
+    This is the season *boundary*, which is not always the date of the first
+    game. The 2026 season opens on this Wednesday, but 2015-2025 all opened on
+    the Thursday one day later. The boundary sits on the Wednesday because that
+    is a no-game day in either case: weeks run Wednesday-to-Tuesday and games
+    fall on Thursday through Monday, so week numbering comes out correct for
+    Wednesday- and Thursday-opening seasons alike.
+
+    Args:
+        season_year: The season year to compute the start date for.
+
+    Returns:
+        The date the season begins.
+    """
+    # Labor Day is the first Monday in September
+    for day in range(1, 8):
+        labor_day = date(season_year, 9, day)
+        if labor_day.weekday() == 0:  # Monday
+            break
+
+    # Wednesday following Labor Day
+    return labor_day + timedelta(days=2)
 
 
 def get_current_season(roster: bool = False) -> int:
@@ -12,7 +41,7 @@ def get_current_season(roster: bool = False) -> int:
     Args:
         roster:
             - If True, uses roster year logic (current year after March 15).
-            - If False, uses season logic (current year after Thursday following Labor Day).
+            - If False, uses season logic (current year after Wednesday following Labor Day).
 
     Returns:
         The current season/roster year.
@@ -31,16 +60,8 @@ def get_current_season(roster: bool = False) -> int:
         march_15 = date(current_year, 3, 15)
         return current_year if today >= march_15 else current_year - 1
     else:
-        # Season logic: current year after Thursday following Labor Day
-        # Labor Day is first Monday in September
-        # Find first Monday in September
-        for day in range(1, 8):
-            if date(current_year, 9, day).weekday() == 0:  # Monday
-                labor_day = date(current_year, 9, day)
-                break
-
-        # Thursday following Labor Day
-        season_start = date(labor_day.year, labor_day.month, labor_day.day + 3)
+        # Season logic: current year after Wednesday following Labor Day
+        season_start = _season_start(current_year)
         return current_year if today >= season_start else current_year - 1
 
 
@@ -50,7 +71,7 @@ def get_current_week(use_date: bool = False, **kwargs) -> int:
 
     Args:
         use_date:
-            - If `True`, calculates week as the number of weeks since Thursday following Labor Day.
+            - If `True`, calculates week as the number of weeks since Wednesday following Labor Day.
             - If `False`, loads schedules via `load_schedules(seasons = get_current_season(**kwargs))` and returns week of the next game.
         **kwargs:
             Arguments passed on to `get_current_season()`
@@ -70,12 +91,8 @@ def get_current_week(use_date: bool = False, **kwargs) -> int:
         today = date.today()
         season_year = get_current_season(**kwargs)
 
-        # NFL season typically starts around first Thursday of September
-        # Find first Thursday in September
-        for day in range(1, 8):
-            if date(season_year, 9, day).weekday() == 3:  # Thursday
-                season_start = date(season_year, 9, day)
-                break
+        # The NFL season starts on the Wednesday following Labor Day
+        season_start = _season_start(season_year)
 
         if today < season_start:
             return 1

--- a/tests/test_utils_date.py
+++ b/tests/test_utils_date.py
@@ -1,0 +1,118 @@
+"""Unit tests for date utilities (no network access required)."""
+
+from datetime import date, timedelta
+from unittest.mock import patch
+
+import pytest
+
+from nflreadpy import utils_date
+from nflreadpy.utils_date import _season_start, get_current_season, get_current_week
+
+
+def _frozen(today: date):
+    """Patch `date.today()` inside utils_date to return a fixed date."""
+
+    class FakeDate(date):
+        @classmethod
+        def today(cls) -> date:
+            return today
+
+    return patch.object(utils_date, "date", FakeDate)
+
+
+class TestSeasonStart:
+    """
+    The season boundary is the Wednesday following Labor Day.
+
+    This is the rollover boundary, not necessarily the date of the first game:
+    2026 opens on that Wednesday, but 2015-2025 all opened on the Thursday one
+    day later. The boundary is deliberately placed on the Wednesday because it
+    falls on a no-game day in either case, so week numbering comes out correct
+    for Wednesday- and Thursday-opening seasons alike.
+    """
+
+    @pytest.mark.parametrize(
+        ("season", "expected"),
+        [
+            (2023, date(2023, 9, 6)),
+            (2024, date(2024, 9, 4)),
+            (2025, date(2025, 9, 3)),
+            (2026, date(2026, 9, 9)),  # 2026 opener: NE @ SEA
+            (2027, date(2027, 9, 8)),
+            (2028, date(2028, 9, 6)),
+        ],
+    )
+    def test_known_season_boundaries(self, season, expected):
+        assert _season_start(season) == expected
+
+    def test_matches_the_2026_opener(self):
+        """2026 is the first season to actually kick off on this boundary."""
+        assert _season_start(2026) == date(2026, 9, 9)
+        assert _season_start(2026).strftime("%A") == "Wednesday"
+
+    @pytest.mark.parametrize("season", range(1999, 2051))
+    def test_always_a_wednesday_after_labor_day(self, season):
+        start = _season_start(season)
+        assert start.weekday() == 2, "season must start on a Wednesday"
+        # Labor Day is the first Monday in September, i.e. two days earlier.
+        labor_day = start - timedelta(days=2)
+        assert labor_day.month == 9
+        assert labor_day.weekday() == 0
+        assert labor_day.day <= 7, "Labor Day is the first Monday in September"
+
+
+class TestGetCurrentSeason:
+    """The season rolls over on opening day, not before."""
+
+    def test_day_before_opener_is_previous_season(self):
+        with _frozen(date(2026, 9, 8)):  # Tuesday
+            assert get_current_season() == 2025
+
+    def test_opening_day_is_new_season(self):
+        with _frozen(date(2026, 9, 9)):  # Wednesday opener
+            assert get_current_season() == 2026
+
+    def test_midseason(self):
+        with _frozen(date(2026, 11, 1)):
+            assert get_current_season() == 2026
+
+    def test_roster_year_flips_on_march_15(self):
+        with _frozen(date(2026, 3, 14)):
+            assert get_current_season(roster=True) == 2025
+        with _frozen(date(2026, 3, 15)):
+            assert get_current_season(roster=True) == 2026
+
+    def test_rejects_non_boolean(self):
+        with pytest.raises(TypeError):
+            get_current_season(roster="yes")  # type: ignore[arg-type]
+
+
+class TestGetCurrentWeekByDate:
+    """Weeks are counted from opening day and roll over on Wednesdays."""
+
+    @pytest.mark.parametrize(
+        ("today", "expected"),
+        [
+            (date(2026, 9, 9), 1),  # opening day
+            (date(2026, 9, 13), 1),  # Sunday of week 1
+            (date(2026, 9, 15), 1),  # Tuesday, still week 1
+            (date(2026, 9, 16), 2),  # Wednesday, week 2 begins
+            (date(2027, 1, 6), 18),  # final week of the regular season
+        ],
+    )
+    def test_week_boundaries(self, today, expected):
+        with _frozen(today):
+            assert get_current_week(use_date=True) == expected
+
+    def test_before_the_opener_returns_week_one(self):
+        # Preseason: the 2026 season has not started, so we are still in 2025.
+        with _frozen(date(2026, 7, 1)):
+            assert get_current_week(use_date=True, roster=True) == 1
+
+    def test_week_is_capped_at_22(self):
+        with _frozen(date(2027, 6, 1)):
+            assert get_current_week(use_date=True) <= 22
+
+    def test_rejects_non_boolean(self):
+        with pytest.raises(TypeError):
+            get_current_week(use_date="yes")  # type: ignore[arg-type]


### PR DESCRIPTION
2026 opens on Wednesday Sept 9 (NE @ SEA) instead of the usual Thursday, so `get_current_season()` and `get_current_week()` would both have rolled over a day late.

The boundary is on the Wednesday for every season, not just 2026. It lands on a no-game day whether the opener is Wednesday or Thursday, so week numbers work out either way — I ran the 2015-2025 schedules through it and got the right week for all but one of 2895 regular season games (2020-12-02, which really was a rescheduled Wednesday game).

Meant to address #60 

Sanity checks against real schedule data:

| date | season | week |
|---|---|---|
| Tue Sep 8 2026 | 2025 | — |
| **Wed Sep 9 2026 (opener)** | **2026** | **1** |
| Tue Sep 15 | 2026 | 1 |
| Wed Sep 16 | 2026 | 2 |