### PR TITLE
feat: support current-team filtering in load_teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # nflreadpy devel
 
+* `load_teams()` now defaults to standardized current team abbreviations, matching nflreadr. Use `current=False` to retain historical and alternate abbreviations (#48).
 * update `load_participation()` season assertions to use improved week-level logic.
 * Added `team_abbr_mapping()`, `team_abbr_mapping_norelocate()`, and `player_name_mapping()`
 

--- a/src/nflreadpy/load_teams.py
+++ b/src/nflreadpy/load_teams.py
@@ -2,12 +2,18 @@
 
 import polars as pl
 
+from .datasets import team_abbr_mapping
 from .downloader import get_downloader
 
 
-def load_teams() -> pl.DataFrame:
+def load_teams(current: bool = True) -> pl.DataFrame:
     """
     Load NFL team information.
+
+    Args:
+        current: If True (the default), return only standardized current team
+            abbreviations from team_abbr_mapping(). Set False to include
+            historical and alternate abbreviations.
 
     Returns:
         Polars DataFrame with team data including abbreviations, names,\
@@ -20,5 +26,10 @@ def load_teams() -> pl.DataFrame:
 
     # Load teams data from nflverse-data repository
     df = downloader.download("nflverse-data", "teams/teams_colors_logos")
+
+    if current:
+        df = df.filter(
+            pl.col("team_abbr").is_in(team_abbr_mapping()["value"].to_list())
+        )
 
     return df

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,8 +1,10 @@
 """Integration tests for all nflreadpy functions."""
 
-import nflreadpy as nfl
 import polars as pl
 import pytest
+
+import nflreadpy as nfl
+from nflreadpy.downloader import get_downloader
 
 
 class TestImports:
@@ -77,12 +79,28 @@ class TestUtilityFunctions:
 class TestStaticDataLoaders:
     """Test loaders that don't require season parameters."""
 
+    @pytest.mark.parametrize("current", [None, True, False])
+    def test_load_teams_current(self, monkeypatch, current):
+        """Filter aliases by default without changing the downloaded data."""
+        teams = pl.DataFrame(
+            {"team_abbr": ["LA", "STL", "LAR", "LV", "OAK"], "color": range(5)}
+        )
+        monkeypatch.setattr(get_downloader(), "download", lambda *args: teams)
+
+        result = (
+            nfl.load_teams() if current is None else nfl.load_teams(current=current)
+        )
+        expected = teams if current is False else teams[[0, 3]]
+        assert result.equals(expected)
+        # A filtered call must not discard historical rows for subsequent callers.
+        assert nfl.load_teams(current=False).equals(teams)
+
     def test_load_teams(self):
         """Test load_teams function."""
         df = nfl.load_teams()
         assert isinstance(df, pl.DataFrame)
         assert len(df) > 0
-        # Should have 32+ teams (accounting for relocations)
+        # Includes current teams and any league/conference entries.
         assert len(df) >= 32
 
     def test_load_players(self):


### PR DESCRIPTION
`load_teams()` currently returns historical and alternate team abbreviations and does not accept the `current` argument available in nflreadr. Add `current: bool = True`, matching the R implementation's default and its use of the existing `team_abbr_mapping` values.

Closes #48.

With the live team dataset checked September 9, 2026:

```python
import nflreadpy as nfl

nfl.load_teams()               # 32 rows: standardized current teams
nfl.load_teams(current=True)   # same result
nfl.load_teams(current=False)  # 36 rows: original unfiltered behavior
```

The current dataset's excluded abbreviations are `LAR`, `OAK`, `SD`, and `STL`; the standardized Rams abbreviation is `LA`. Filtering derives from the bundled mapping, not a hardcoded list or team count. The downloaded/cached frame is preserved for callers requesting all entries.

### Changes

- `src/nflreadpy/load_teams.py`: optional filter using the existing mapping; document the argument and default.
- `tests/test_integration.py`: regression coverage for default, explicit true, and false; check row order, metadata, and preservation of the unfiltered frame.
- `CHANGELOG.md`: explain the new default and the `current=False` migration path.

### Validation

Native Windows, Python 3.11.15; locked development dependencies.

- New regression: all three cases fail against original main and pass with the change.
- `python -m pytest tests -v`: **51 passed**, including live-data integration tests.
- Separate live-data check: 32 default rows, 36 unfiltered rows; repeated unfiltered calls retain the complete dataset.
- Ruff lint and formatting on changed Python files: pass.
- MkDocs build: pass; the existing `utils_date.py` missing-annotation warning remains.
- `git diff --check`: pass.
- `mypy src`: 5 errors in unchanged `datasets.py` and `utils_date.py`. Repeating mypy with the original `load_teams.py` produces the same 5 errors; no new errors from this patch.

Base: `c54316e16fb6cbbfbc52ed2a9c07fca070a0c636`.

No overlapping PR appeared in the all-state `current load_teams` search. This deliberately changes the no-argument default to match nflreadr; callers needing historical/alternate rows should pass `current=False`.

Prepared with Codex assistance; all reported tests were run locally.